### PR TITLE
修复happy漫画源图片无法加载

### DIFF
--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -37,6 +37,7 @@ export interface ReaderProps {
     pre: number;
     current: number;
     chapterHash: string;
+    isBase64Image?: boolean;
   }[];
   headers?: Chapter['headers'];
   onTap?: (position: PositionX) => void;
@@ -178,7 +179,7 @@ const Reader: ForwardRefRenderFunction<ReaderRef, ReaderProps> = (
     onPageChangeRef.current && onPageChangeRef.current(last.item[0].pre + last.item[0].current - 1);
   };
   const renderHorizontalItem = ({ item, index }: ListRenderItemInfo<(typeof data)[0]>) => {
-    const { uri, scrambleType, needUnscramble } = item;
+    const { uri, scrambleType, needUnscramble, isBase64Image = false } = item;
     const horizontalState = horizontalStateRef.current[index] || undefined;
     return (
       <Controller
@@ -194,6 +195,7 @@ const Reader: ForwardRefRenderFunction<ReaderRef, ReaderProps> = (
           index={index}
           scrambleType={scrambleType}
           needUnscramble={needUnscramble}
+          isBase64Image={isBase64Image}
           headers={headers}
           prevState={horizontalState}
           defaultPortraitHeight={defaultPortraitHeightRef.current}
@@ -208,7 +210,7 @@ const Reader: ForwardRefRenderFunction<ReaderRef, ReaderProps> = (
     );
   };
   const renderVerticalItem = ({ item, index }: ListRenderItemInfo<(typeof data)[0]>) => {
-    const { uri, scrambleType, needUnscramble } = item;
+    const { uri, scrambleType, needUnscramble, isBase64Image = false } = item;
     const verticalState = verticalStateRef.current[index] || undefined;
     const cacheState = cache.getImageState(uri);
     return (
@@ -237,6 +239,7 @@ const Reader: ForwardRefRenderFunction<ReaderRef, ReaderProps> = (
             index={index}
             scrambleType={scrambleType}
             needUnscramble={needUnscramble}
+            isBase64Image={isBase64Image}
             headers={headers}
             prevState={verticalState}
             defaultPortraitHeight={defaultPortraitHeightRef.current}
@@ -271,37 +274,47 @@ const Reader: ForwardRefRenderFunction<ReaderRef, ReaderProps> = (
         onZoomEnd={onZoomEnd}
       >
         <Flex w="full" h="full" flexDirection="row" alignItems="center" justifyContent="center">
-          {item.map(({ uri, scrambleType, needUnscramble, chapterHash, current }) => {
-            const multipleState = (multipleStateRef.current[index] || [])[uri] || undefined;
-            return (
-              <Box key={uri}>
-                <LongPressController
-                  onLongPress={() =>
-                    onLongPress && onLongPress(PositionX.Mid, multipleState?.dataUrl)
-                  }
-                >
-                  <ComicImage
-                    uri={uri}
-                    index={index}
-                    scrambleType={scrambleType}
-                    needUnscramble={needUnscramble}
-                    headers={headers}
-                    prevState={multipleState}
-                    defaultPortraitHeight={defaultPortraitHeightRef.current}
-                    defaultLandscapeHeight={defaultLandscapeHeightRef.current}
-                    layoutMode={LayoutMode.Multiple}
-                    onChange={(state, idx = index) => {
-                      if (typeof multipleStateRef.current[idx] !== 'object') {
-                        multipleStateRef.current[idx] = {};
-                      }
-                      multipleStateRef.current[idx][uri] = state;
-                      onImageLoad && onImageLoad(uri, chapterHash, current);
-                    }}
-                  />
-                </LongPressController>
-              </Box>
-            );
-          })}
+          {item.map(
+            ({
+              uri,
+              scrambleType,
+              needUnscramble,
+              chapterHash,
+              current,
+              isBase64Image = false,
+            }) => {
+              const multipleState = (multipleStateRef.current[index] || [])[uri] || undefined;
+              return (
+                <Box key={uri}>
+                  <LongPressController
+                    onLongPress={() =>
+                      onLongPress && onLongPress(PositionX.Mid, multipleState?.dataUrl)
+                    }
+                  >
+                    <ComicImage
+                      uri={uri}
+                      index={index}
+                      scrambleType={scrambleType}
+                      needUnscramble={needUnscramble}
+                      isBase64Image={isBase64Image}
+                      headers={headers}
+                      prevState={multipleState}
+                      defaultPortraitHeight={defaultPortraitHeightRef.current}
+                      defaultLandscapeHeight={defaultLandscapeHeightRef.current}
+                      layoutMode={LayoutMode.Multiple}
+                      onChange={(state, idx = index) => {
+                        if (typeof multipleStateRef.current[idx] !== 'object') {
+                          multipleStateRef.current[idx] = {};
+                        }
+                        multipleStateRef.current[idx][uri] = state;
+                        onImageLoad && onImageLoad(uri, chapterHash, current);
+                      }}
+                    />
+                  </LongPressController>
+                </Box>
+              );
+            }
+          )}
         </Flex>
       </Controller>
     );

--- a/src/plugins/happy.ts
+++ b/src/plugins/happy.ts
@@ -269,6 +269,8 @@ class HappyManga extends Base {
   }
 
   private v = 'v2.13';
+  // 单独的漫画version
+  private readv = 'v3.1613134';
   private checkProxy<T = any>(res: T | string): res is T {
     if (typeof res === 'string') {
       this.checkCloudFlare(cheerio.load(res || ''));
@@ -322,15 +324,15 @@ class HappyManga extends Base {
   prepareChapterListFetch: Base['prepareChapterListFetch'] = () => {};
   prepareChapterFetch: Base['prepareChapterFetch'] = (mangaId, chapterId) => {
     return {
-      url: 'https://m.happymh.com/v2.0/apis/manga/read',
+      url: 'https://m.happymh.com/v2.0/apis/manga/reading',
       body: {
         code: mangaId,
         cid: chapterId,
-        v: this.v,
+        v: this.readv,
       },
       headers: new Headers({
         ...this.defaultHeaders,
-        Referer: `https://m.happymh.com/reads/${mangaId}/${chapterId}`,
+        Referer: `https://m.happymh.com/mangaread/${mangaId}/${chapterId}`,
         /** 不是 XML 请求会返回 403 */
         'X-Requested-With': 'XMLHttpRequest',
       }),
@@ -355,6 +357,7 @@ class HappyManga extends Base {
             bookCover: item.cover,
             title: item.name,
             latest: item.last_chapter,
+            headers: this.defaultHeaders,
           };
         }),
       };
@@ -382,6 +385,7 @@ class HappyManga extends Base {
             title: item.name,
             tag: item.genre_ids.split('、'),
             author: [item.author],
+            headers: this.defaultHeaders,
           };
         }),
       };
@@ -469,7 +473,7 @@ class HappyManga extends Base {
           name: res.data.manga_name,
           title: res.data.chapter_name,
           headers: { ...this.defaultHeaders, Referer: 'https://m.happymh.com/' },
-          images: res.data.scans.map((item) => ({ uri: item.url })),
+          images: res.data.scans.map((item) => ({ uri: item.url, isBase64Image: true })),
         },
       };
     } else {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,7 +1,7 @@
 import { FileSystem, Dirs } from 'react-native-file-access';
 import { ImageState } from '~/components/ComicImage';
 
-type CacheMap = Record<string, ImageState>;
+type CacheMap = Record<string, Omit<ImageState, 'dataUrl' | 'loadStatus'>>;
 
 class Cache {
   private _basePath = `${Dirs.DocumentDir}/@cache`; // 或者Dirs.CacheDir？
@@ -34,8 +34,12 @@ class Cache {
     return this._cacheMap[uri];
   }
 
-  setImageState(uri: string, state: ImageState) {
-    this._cacheMap[uri] = state;
+  // 去掉不需要存的dataUrl和loadStatus
+  setImageState(
+    uri: string,
+    { landscapeHeight, portraitHeight, multipleFitWidth, multipleFitHeight }: ImageState
+  ) {
+    this._cacheMap[uri] = { landscapeHeight, portraitHeight, multipleFitWidth, multipleFitHeight };
   }
 
   async storeCacheMap() {

--- a/src/views/Chapter.tsx
+++ b/src/views/Chapter.tsx
@@ -70,6 +70,7 @@ const useChapterFlat = (hashList: string[], dict: RootState['dict']['chapter']) 
       multiplePre: number;
       current: number;
       chapterHash: string;
+      isBase64Image?: boolean;
     }[] = [];
 
     hashList.forEach((hash) => {


### PR DESCRIPTION

https://github.com/user-attachments/assets/68926f86-8f04-45a2-bad4-3167912015d3

happy这个漫画源好坑，好多地方它返回格式不一样。

发现了一个不错的图片库https://github.com/candlefinance/faster-image，维护挺积极的，可以用来替代原本的缓存图片组件跟原生Image组件